### PR TITLE
fix: exif buffer problem

### DIFF
--- a/scripts/build-manifest.ts
+++ b/scripts/build-manifest.ts
@@ -374,12 +374,27 @@ async function extractExifData(
       return null
     }
 
+    let startIndex = 0
+    for (let i = 0; i < metadata.exif.length; i++) {
+      if (
+        metadata.exif.toString('ascii', i, i + 2) === 'II' ||
+        metadata.exif.toString('ascii', i, i + 2) === 'MM'
+      ) {
+        startIndex = i
+        break
+      }
+      if (metadata.exif.toString('ascii', i, i + 4) === 'Exif') {
+        startIndex = i
+        break
+      }
+    }
+    const exifBuffer = metadata.exif.subarray(startIndex)
+
     // 使用 exif-reader 解析 EXIF 数据
-    const exifData = exifReader(metadata.exif)
+    const exifData = exifReader(exifBuffer)
 
     if (exifData.Photo?.MakerNote) {
       const recipe = getRecipe(exifData.Photo.MakerNote)
-
       ;(exifData as any).FujiRecipe = recipe
     }
 


### PR DESCRIPTION
### Description

`exif-reader` 对 buffer 的要求非常严格，实测小米14拍的 HEIC 经过sharp解出来的buffer会有一些问题。不是以 `MM`, `II`, `Exif` 开头。为了让 exif-reader 不报错要去掉。

`exiftool` cli 是能够从 HEIC 中解出正确exif信息的，所以我觉得这里可能是 sharp的问题，这是一个workaround.

<img width="959" alt="image" src="https://github.com/user-attachments/assets/4b647c80-4484-49c8-b8df-c94062a68528" />


### Linked Issues

https://github.com/devongovett/exif-reader/issues/32

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
